### PR TITLE
Extended parameters

### DIFF
--- a/PowerShell/CreateIteration/CreateIteration.ps1
+++ b/PowerShell/CreateIteration/CreateIteration.ps1
@@ -1,23 +1,48 @@
-﻿Param
+# Prerequisites:
+# 1. Install the Azure CLI (https://aka.ms/install-azure-cli). You must have at least v2.0.49, which you can verify with az --version command.
+# 2. Add the Azure DevOps Extension az extension add --name azure-devops
+# 3. Run the az login command first, then there is no need for a PAT
+# 4. Set parameters in this script and run
+
+Param
 (
     [string]$PAT,
     [string]$Organization,
     [string]$Project,
     [string]$TeamName,
     [DateTime]$StartDate,
-    [int]$NumberOfSprints
+    [int]$CurrentSprint,
+    [int]$NumberOfSprints,
+    [int]$SprintFrequency,
+    [int]$SprintLength
 )
 
-echo $PAT | az devops login --org $Organization
+# Example parameters
+$Organization = 'https://dev.azure.com/ORGANIZATION/'
+$Project = 'PROJECT'
+$TeamName = 'TEAM'
+# set start date for first new sprint
+$StartDate = [DateTime]::Parse('21-5-2021') #or: [DateTime]'5/21/2021' (PS uses US format)
+# set last sprint already available in DevOps
+$CurrentSprint = 10 
+# set number of sprints to add
+$NumberOfSprints = 20
+# set frequency (number of days)
+$SprintFrequency = 14
+# set length of sprint (number of days)
+$SprintLength = 13
+
+# no longer required if already signed in with 'az login': https://docs.microsoft.com/nl-nl/azure/devops/cli/log-in-via-pat?view=azure-devops&tabs=windows
+#echo $PAT | az devops login --org $Organization
 
 Write-Host '===Configuring connection to organization and Team Project'
 az devops configure --defaults organization=$Organization project=$Project
 
 For ($i=1; $i -le $NumberOfSprints; $i++) 
 {
-    $Sprint = 'Sprint ' + $i
-    $StartDateIteration = $StartDate.AddDays(($i - 1) * 14)
-    $FinishDateIteration = $StartDateIteration.AddDays(11)
+    $Sprint = 'Sprint ' + ($CurrentSprint + $i)
+    $StartDateIteration = $StartDate.AddDays(($i - 1) * $SprintFrequency)
+    $FinishDateIteration = $StartDateIteration.AddDays($SprintLength)
     $createIteration = az boards iteration project create --name $Sprint --start-date $StartDateIteration --finish-date $FinishDateIteration --org $Organization --project $Project | ConvertFrom-Json
     $addIteration = az boards iteration team add --id $createIteration.Identifier --team $TeamName --org $Organization --project $Project | ConvertFrom-Json
     Write-Host $addIteration.name 'created on path'$addIteration.path


### PR DESCRIPTION
Some changes and extensions to allow for starting from a certain sprint number, to easier set frequency and length (e.g. when sprints starts on Fridays and end on Thursdays). Also added prerequisites and some example parameters, for those (like me) who are not very proficient with PowerShell scripts.
Logging in using PAT could be optional, because 'az devops' commands now support sign in through 'az login'.