### PR TITLE
Inclusion of the -UseBasicParsing parameter in the Projects file

### DIFF
--- a/AllReports/PowerShell/Projects.ps1
+++ b/AllReports/PowerShell/Projects.ps1
@@ -33,7 +33,7 @@ $projectStatsBody = @{
         }
     }  | ConvertTo-Json -Depth 5
 
-$projectStatsResult = Invoke-WebRequest -Uri $uriProjectStats -Headers $AzureDevOpsAuthenicationHeader -Method Post -Body $projectStatsBody 
+$projectStatsResult = Invoke-WebRequest -Uri $uriProjectStats -Headers $AzureDevOpsAuthenicationHeader -Method Post -Body $projectStatsBody -UseBasicParsing 
 $projectStatsJson = ConvertFrom-Json $projectStatsResult.Content
 
 $workItemsCreated = 0


### PR DESCRIPTION
#10 
When trying to run the solution in an environment with Windows Server 2016, the following bug occurred when trying to include records in the dbo.Projects table "The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."
After including the -UseBasicParsing parameter, the script was able to record the information in the table